### PR TITLE
feat(modules): auto-register tenant-specific plugin modules on import

### DIFF
--- a/src/openaec_reports/modules/__init__.py
+++ b/src/openaec_reports/modules/__init__.py
@@ -114,3 +114,26 @@ class ModuleRegistry:
 
 
 __all__ = ["ContentModule", "ModuleConfig", "ModuleRegistry"]
+
+
+# Auto-register tenant-specific plugin modules on package import.
+#
+# Plugin packages leven privé (buiten deze repo, bv. in openaec-tenants).
+# Als een plugin package geïnstalleerd is bundelt de image-build hem in
+# ``openaec_reports.modules.<tenant>`` en roept onderstaande hook de
+# bijbehorende ``register_*_modules()`` functie aan. Wanneer een plugin
+# niet aanwezig is (bv. in de publieke open-source build), slaan we het
+# stilzwijgend over zonder breaking imports.
+_TENANT_PLUGINS = (
+    ("openaec_reports.modules.symitech", "register_symitech_modules"),
+    # Nieuwe tenant-plugins hier toevoegen:
+    # ("openaec_reports.modules.<tenant>", "register_<tenant>_modules"),
+)
+
+for _module_path, _register_fn in _TENANT_PLUGINS:
+    try:
+        _mod = __import__(_module_path, fromlist=[_register_fn])
+        getattr(_mod, _register_fn)()
+    except (ImportError, AttributeError):
+        # Plugin niet geïnstalleerd (publieke build) of register-fn afwezig.
+        pass


### PR DESCRIPTION
## Summary

Voegt een idempotente auto-registratie hook toe voor tenant-specifieke Python modules bij package import. Lost het probleem op waar Symitech custom blocks faalden na de tenant-purge.

## Achtergrond

Tijdens de tenant-purge van 15 april (commit `a2edfe2`) werd `src/openaec_reports/modules/symitech/` toegevoegd aan `.gitignore` om tenant-specifieke modules privé te houden. Echter:

1. Er was geen auto-register mechanisme voor tenant plugins
2. Bestaande productie containers werkten via hand-patches die ontstonden vóór de purge
3. Bij container rebuilds verdwenen die patches → Symitech custom-blocks (cost_summary/bic_table) faalden met "Onbekend content block type"

## Deze wijziging

- **Veilige registratie:** try/except hook die tenant plugins registreert als aanwezig, stilzwijgend skip als niet
- **Publieke builds blijven werken:** geen ImportError bij ontbrekende tenant modules  
- **Geen breaking changes:** bestaande deployments blijven functioneren
- **Extensible pattern:** nieuwe tenant plugins eenvoudig toe te voegen

## Plugin architectuur

```python
# In openaec_reports.modules.symitech (privé):
def register_symitech_modules():
    registry.register_module("cost_summary", CostSummaryModule)
    registry.register_module("bic_table", BicTableModule)
    # etc.

# Auto-hook roept deze functie aan bij package import
```

## Verwacht vervolgwerk

**In andere repos/PR's:**
- [ ] Symitech Python modules naar `openaec-tenants` private repo (of dedicated private repo) 
- [ ] Dockerfile hooks voor tenant plugin bundling tijdens build
- [ ] ADR documentatie: 2-engine strategie (TemplateEngine YAML-driven + Report Python-based)

## Test plan

- [ ] Public build: package import werkt zonder errors, geen tenant blocks beschikbaar
- [ ] Private build: tenant modules worden automatisch geregistreerd bij import
- [ ] Bestaande reports blijven functioneren
- [ ] Symitech cost_summary/bic_table blocks werken na container rebuild

## Gerelateerde commits

- Tenant-purge: `a2edfe2 security(tenants): purge tenant-data from public repo`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)