### PR TITLE
fix(api): serve SPA when installed via pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN mkdir -p /app/uploads /app/data && chown -R appuser:appuser /app
 # Default tenant is de neutrale open-source placeholder onder tenants/default.
 # Productie-deployments kunnen een andere tenant bind-mounten en de env
 # vars OPENAEC_DEFAULT_BRAND + OPENAEC_TENANT_DIR overschrijven.
+ENV OPENAEC_STATIC_DIR=/app/static
 ENV OPENAEC_TENANTS_ROOT=/app/tenants
 ENV OPENAEC_TENANT_DIR=/app/tenants/default
 ENV OPENAEC_DEFAULT_BRAND=default

--- a/src/openaec_reports/api.py
+++ b/src/openaec_reports/api.py
@@ -972,7 +972,17 @@ async def pdok_services(user: User = Depends(get_current_user)):
 # Static frontend (moet ONDERAAN staan, na alle API routes)
 # ============================================================
 
-_static_dir = Path(__file__).parent.parent.parent / "static"
+# When the package is installed via `pip install .` (e.g. in the Docker
+# image), api.py lives under site-packages and the relative
+# `parent.parent.parent / "static"` path no longer points at /app/static.
+# Allow an env override and fall back to the source-tree-relative path so
+# in-place dev runs from the repo root still work.
+_static_dir = Path(
+    os.environ.get(
+        "OPENAEC_STATIC_DIR",
+        str(Path(__file__).parent.parent.parent / "static"),
+    )
+)
 if _static_dir.exists():
     # Kopieer uitleg.html naar static dir zodat /uitleg.html direct werkt
     _docs_dir = _find_docs_dir()


### PR DESCRIPTION
After `pip install .`, `api.py` runs from site-packages so `Path(__file__).parent.parent.parent / "static"` no longer points at `/app/static`. The mount silently no-ops and every non-API URL returns FastAPI's default 404.

Adds an `OPENAEC_STATIC_DIR` env override (Dockerfile pins it to `/app/static`), falls back to the old relative path so in-place dev runs still work.